### PR TITLE
Explicit section and paragraph numbering

### DIFF
--- a/clause.html
+++ b/clause.html
@@ -24,14 +24,22 @@ limitations under the License.
         }
       }
       Polymer('cxx-clause', {
-        // Convenience function at the clause level, which gets called from <cxx-toc>.
+        
+        // Convenience function at the clause level, which gets called 
+        // from <cxx-toc>. If the clause is explicitly numbered, then
+        // this sets the clause_num to that value. Otherwise, the clause
+        // number is set to the argument clause_num. This returns
+        // 1 + the value set.
+        //
+        // Note that this will recursively set the section numbers for
+        // this clause.
         set_clause_num: function(clause_num) {
           // If the author explicitly specified the clause number, don't
           // use a different number.
           if (this.number)
-            clause_num = this.number
+            clause_num = Number(this.number)
           this.update_sec_nums(clause_num);
-          return clause_num;
+          return clause_num + 1;
         },
 
         domReady: updateTocClauses,

--- a/clause.html
+++ b/clause.html
@@ -31,6 +31,7 @@ limitations under the License.
           if (this.number)
             clause_num = this.number
           this.update_sec_nums(clause_num);
+          return clause_num;
         },
 
         domReady: updateTocClauses,

--- a/clause.html
+++ b/clause.html
@@ -26,6 +26,10 @@ limitations under the License.
       Polymer('cxx-clause', {
         // Convenience function at the clause level, which gets called from <cxx-toc>.
         set_clause_num: function(clause_num) {
+          // If the author explicitly specified the clause number, don't
+          // use a different number.
+          if (this.number)
+            clause_num = this.number
           this.update_sec_nums(clause_num);
         },
 

--- a/section.html
+++ b/section.html
@@ -17,7 +17,7 @@ limitations under the License.
     Recognizes attributes 'id' and 'title', but marking these as attributes
     cause problems for the ShadowDOM polyfill.
 -->
-<polymer-element name="cxx-section" constructor="CxxSectionElement">
+<polymer-element name="cxx-section" constructor="CxxSectionElement" attributes="number">
   <template>
     <style>
       :host { display: block; }

--- a/section.js
+++ b/section.js
@@ -71,6 +71,10 @@ limitations under the License.
         },
 
         numberParagraph: function(number, element) {
+            // If the paragraph is explicitly numbered, use that number.
+            if (element.hasAttribute("number"))
+                number = element.getAttribute("number")
+
             var id = this.id + '.' + number;
             if (element.id) {
                 console.warn('Paragraph already has id:', element);

--- a/section.js
+++ b/section.js
@@ -30,10 +30,8 @@ limitations under the License.
             // Assume there aren't any elements between cxx-section levels.
             for (var child = this.firstChild; child; child = child.nextSibling) {
                 if (child instanceof CxxSectionElement) {
-                    if (child.number) {
+                    if (child.number)
                         child_index = Number(child.number);
-                        console.log(child.number)
-                    }
                     child.update_sec_nums(this.sec_num + '.' + child_index);
                     child_index++;
                 }

--- a/section.js
+++ b/section.js
@@ -61,14 +61,13 @@ limitations under the License.
                  child = child.nextElementSibling) {
                 if (child instanceof CxxSectionElement)
                     return para_num;
-                else if (child instanceof HTMLParagraphElement &&
-                         !child.classList.contains('cont'))
-                    this.numberParagraph(para_num++, child);
+                else if (child instanceof HTMLParagraphElement && !child.classList.contains('cont'))
+                    para_num = this.numberParagraph(para_num, child);
                 else if (child instanceof CxxFunctionElement) {
-                    this.numberParagraph(para_num++, child);
+                    para_num = this.numberParagraph(para_num, child);
                     para_num = this.numberParagraphChildren(child, para_num);
                 } else if (child instanceof CxxFunctionAttributeElement)
-                    this.numberParagraph(para_num++, child);
+                    para_num = this.numberParagraph(para_num, child);
             }
             return para_num;
         },
@@ -76,7 +75,7 @@ limitations under the License.
         numberParagraph: function(number, element) {
             // If the paragraph is explicitly numbered, use that number.
             if (element.hasAttribute("number"))
-                number = element.getAttribute("number")
+                number = Number(element.getAttribute("number"))
 
             var id = this.id + '.' + number;
             if (element.id) {
@@ -88,6 +87,7 @@ limitations under the License.
                 element.id = id;
             }
             element.setAttribute('para_num', number);
+            return number + 1
         }
     })
 })();

--- a/section.js
+++ b/section.js
@@ -30,7 +30,12 @@ limitations under the License.
             // Assume there aren't any elements between cxx-section levels.
             for (var child = this.firstChild; child; child = child.nextSibling) {
                 if (child instanceof CxxSectionElement) {
-                    child.update_sec_nums(this.sec_num + '.' + (child_index++));
+                    if (child.number) {
+                        child_index = Number(child.number);
+                        console.log(child.number)
+                    }
+                    child.update_sec_nums(this.sec_num + '.' + child_index);
+                    child_index++;
                 }
             }
         },

--- a/toc.js
+++ b/toc.js
@@ -36,9 +36,11 @@ limitations under the License.
         },
 
         clausesChanged: function() {
-            var n = 1
-            while (n < this.clauses.length) {
-                n = this.clause[n].set_clause_num(n)
+            var clause_num = 1;
+            for (var i = 0; i < this.clauses.length; ++i) {
+                var clause = this.clauses[i];
+                clause_num = clause.set_clause_num(clause_num);
+                this.sections.push(this.collectSections(clause));
             }
 
             // this.sections = this.clauses.array().map(function(clause, index) {

--- a/toc.js
+++ b/toc.js
@@ -36,10 +36,15 @@ limitations under the License.
         },
 
         clausesChanged: function() {
-            this.sections = this.clauses.array().map(function(clause, index) {
-                clause.set_clause_num(index + 1);
-                return this.collectSections(clause);
-            }, this);
+            var n = 1
+            while (n < this.clauses.length) {
+                n = this.clause[n].set_clause_num(n)
+            }
+
+            // this.sections = this.clauses.array().map(function(clause, index) {
+            //     clause.set_clause_num(index + 1);
+            //     return this.collectSections(clause);
+            // }, this);
         },
 
         domReady: function() {


### PR DESCRIPTION
This allows a number="N" attribute on cxx-clauses, cxx-sections, and p. Subsequent sections and paragraphs are numbered starting at the next number.
